### PR TITLE
Optimized code for fewer API calls

### DIFF
--- a/Bash Scripts/bwConfirmAcceptedPeople_MoveGroupToManager.sh
+++ b/Bash Scripts/bwConfirmAcceptedPeople_MoveGroupToManager.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Depends on file "secureString.txt" which can be created by first running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#69 > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#69 > secureString.txt
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#69 > secureString_secret.txt
+# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#69 > secureString_secret.txt
 # create groups.txt. One group name each line. Only members in these groups will be upgraded to Manager
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
@@ -31,7 +31,7 @@ done < groups.txt
 
 # Set up CLI and API auth
 
-org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#69)
 org_client_id=("organization.$organization_id")
 
@@ -57,7 +57,7 @@ while read -r group; do
 done < <(curl -s -X GET $api_url/public/groups/ -H "Authorization: Bearer $bearer_token" | jq -c '.data[]')
 
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#69)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/bwConfirmAcceptedPeople_MoveToManager.sh
+++ b/Bash Scripts/bwConfirmAcceptedPeople_MoveToManager.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Depends on file "secureString.txt" which can be created by first running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#69 > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#69 > secureString.txt
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#69 > secureString_secret.txt
+# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#69 > secureString_secret.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
 # openssl is required in $PATH https://www.openssl.org/
@@ -20,7 +20,7 @@ fi
 
 # Set up CLI and API auth
 
-org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#69)
 org_client_id=("organization.$organization_id")
 
@@ -30,7 +30,7 @@ bearer_token="$(curl -X POST $identity_url/connect/token -H 'Content-Type: appli
 
 # Perform CLI and API auth
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#69)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/createCollectionsForAllGroups.sh
+++ b/Bash Scripts/createCollectionsForAllGroups.sh
@@ -2,9 +2,9 @@
 # Depends on file "secureString.txt" which can be created as an encrypted file by replacing all references in this script to:
 # replacewithyoursupersecretstring
 # With your own encryption phrase, and then running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:replacewithyoursupersecretstring > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:replacewithyoursupersecretstring > secureString.txt
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:replacewithyoursupersecretstring > secureString_secret.txt
+# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:replacewithyoursupersecretstring > secureString_secret.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
 # openssl is required in $PATH https://www.openssl.org/
@@ -22,7 +22,7 @@ fi
 
 # Set up CLI and API auth
 
-org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:replacewithyoursupersecretstring)
 org_client_id=("organization.$organization_id")
 
@@ -32,7 +32,7 @@ bearer_token="$(curl -sX POST $identity_url/connect/token -H 'Content-Type: appl
 
 # Perform CLI and API auth
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:replacewithyoursupersecretstring)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/createCollectionsForAllMembers.sh
+++ b/Bash Scripts/createCollectionsForAllMembers.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Depends on file "secureString.txt" which can be created by first running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#99 > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#99 > secureString.txt
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#99 > secureString_secret.txt
+# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#99 > secureString_secret.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
 # openssl is required in $PATH https://www.openssl.org/
@@ -21,10 +21,10 @@ fi
 
 # Set up CLI and API auth
 
-org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#99)
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#99)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/createCollectionsForAllMembersNested.sh
+++ b/Bash Scripts/createCollectionsForAllMembersNested.sh
@@ -20,34 +20,74 @@ else
 fi
 
 # Set up CLI and API auth
+org_client_secret_key=$(cat secureString_secret.txt \
+	| openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+	 -salt -pass pass:Secret@Bitwarden#99)
 
-org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
- -salt -pass pass:Secret@Bitwarden#99)
-
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
- -salt -pass pass:Secret@Bitwarden#99)
+password=$(cat secureString.txt \
+	| openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+	 -salt -pass pass:Secret@Bitwarden#99)
 
 session_key="$(printf $password | bw unlock --raw)"
 export BW_SESSION="$session_key"
-bearer_token="$(curl -sX POST $identity_url/connect/token -H 'Content-Type: application/x-www-form-urlencoded' -d 'grant_type=client_credentials&scope=api.organization&client_id='organization.$organization_id'&client_secret='$org_client_secret_key'' | cut -d '"' -f4)"
-org_members="$(curl -sX GET $api_url/public/members -H 'Content-Type: application/json' -H 'Authorization: Bearer '$bearer_token'' | jq -r '.data[] | select(.status == 2) | .name')"
 
-IFS=$'\n'
+bearer_token="$(curl -sX POST $identity_url/connect/token \
+	-H 'Content-Type: application/x-www-form-urlencoded' \
+	-d 'grant_type=client_credentials&scope=api.organization&client_id='organization.$organization_id'&client_secret='$org_client_secret_key'' \
+	| cut -d '"' -f4)"
 
+all_collections="$(bw list org-collections --organizationid $organization_id)"
+collection_template="$(bw get template org-collection)"
+
+allorgmembers="$(curl -sX GET $api_url/public/members \
+	-H 'Content-Type: application/json' \
+	-H 'Authorization: Bearer '$bearer_token'' \
+	| jq 'del(.object)')"
+
+org_members="$(jq -r '.data[] | select(.status == 2) | .email' <<< "$allorgmembers")"
+
+#Loop over all users and create a collection with their e-mail
 for member in ${org_members[@]}; do
 
-if (bw list org-collections --organizationid $organization_id | jq -r '.[].name' | grep -x "Personal Collections/$member" > /dev/null); then
-echo "$member already has a Collection, skipping"
+    if (echo $all_collections | jq -r '.[].name' | grep -x "Personal Collections/$member" > /dev/null); then
+    echo "$member already has a Collection, skipping"
 
 else
 
-allorgmembers="$(curl -sX GET $api_url/public/members -H 'Content-Type: application/json' -H 'Authorization: Bearer '$bearer_token'' | jq 'del(.object)')"
-memberid="$(jq -r -c --arg n "$member" '.data[] | select(.name==$n) | .id' <<< "$allorgmembers")"
-origmemberbody="$(curl -sX GET $api_url/public/members/$memberid -H 'Content-Type: application/json' -H 'Authorization: Bearer '$bearer_token''| jq -r -c 'del(.object)')"
-collectionid="$(bw get template org-collection | jq -c --arg n "$member" --arg c "$organization_id" '.name="Personal Collections/" + $n | .organizationId=$c | del(.groups[1])' | bw encode | bw create org-collection --organizationid $organization_id | jq -r '.id')"
-newmemberbody=$(jq -r -c --arg newcol "$collectionid" --arg i "$memberid" 'select(.id==$i) | .collections += [{"id": $newcol, "readOnly": false, "hidePasswords": false, "manage": true}]' <<< "$origmemberbody")
-curl -sX PUT $api_url/public/members/$memberid -H 'Content-Type: application/json' -H 'Authorization: Bearer '$bearer_token'' -d $newmemberbody > /dev/null
-echo "Created Collection for $member"
+    memberid="$(jq -r -c --arg n "$member" '.data[] | select(.email==$n) | .id' <<< "$allorgmembers")"
+
+    collectionid="$(echo $collection_template \
+	| jq -c --arg n "$member" --arg c "$organization_id" --arg m "$memberid" \
+	'.name="Personal Collections/" + $n | .organizationId=$c | del(.groups[1]) | del(.groups[0]) | del(.users[1]) | .users[0].id=$m | .users[0].manage=true' \
+	| bw encode \
+	| bw create org-collection --organizationid $organization_id \
+	| jq -r '.id')"
+
+    echo "Created Collection for $member"
+fi
+
+done
+
+
+
+
+for member in ${org_members[@]}; do
+
+    if (echo $all_collections | jq -r '.[].name' | grep -x "Personal Collections/$member" > /dev/null); then
+    echo "$member already has a Collection, skipping"
+
+else
+
+    memberid="$(jq -r -c --arg n "$member" '.data[] | select(.email==$n) | .id' <<< "$allorgmembers")"
+
+    collectionid="$(echo $collection_template \
+	| jq -c --arg n "$member" --arg c "$organization_id" --arg m "$memberid" \
+	'.name="Personal Collections/" + $n | .organizationId=$c | del(.groups[1]) | del(.groups[0]) | del(.users[1]) | .users[0].id= $m | .users[0].manage=true' \
+	| bw encode \
+	| bw create org-collection --organizationid $organization_id \
+	| jq -r '.id')"
+
+    echo "Created Collection for $member"
 fi
 
 done

--- a/Bash Scripts/createCollectionsForAllMembersNested.sh
+++ b/Bash Scripts/createCollectionsForAllMembersNested.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Depends on file "secureString.txt" which can be created by first running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#99 > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#99 > secureString.txt
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#99 > secureString_secret.txt
+# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#99 > secureString_secret.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
 # openssl is required in $PATH https://www.openssl.org/
@@ -21,11 +21,11 @@ fi
 
 # Set up CLI and API auth
 org_client_secret_key=$(cat secureString_secret.txt \
-	| openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+	| openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
 	 -salt -pass pass:Secret@Bitwarden#99)
 
 password=$(cat secureString.txt \
-	| openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+	| openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
 	 -salt -pass pass:Secret@Bitwarden#99)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/createCollectionsForAllMembersNested.sh
+++ b/Bash Scripts/createCollectionsForAllMembersNested.sh
@@ -31,6 +31,7 @@ password=$(cat secureString.txt \
 session_key="$(printf $password | bw unlock --raw)"
 export BW_SESSION="$session_key"
 
+IFS=$'\n'
 bearer_token="$(curl -sX POST $identity_url/connect/token \
 	-H 'Content-Type: application/x-www-form-urlencoded' \
 	-d 'grant_type=client_credentials&scope=api.organization&client_id='organization.$organization_id'&client_secret='$org_client_secret_key'' \

--- a/Bash Scripts/createMissingParents.sh
+++ b/Bash Scripts/createMissingParents.sh
@@ -2,7 +2,7 @@
 # Depends on file "secureString.txt" which can be created as an encrypted file by replacing all references in this script to:
 # replacewithyoursupersecretstring
 # With your own encryption phrase, and then running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:replacewithyoursupersecretstring > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:replacewithyoursupersecretstring > secureString.txt
 # Assumes a list of Collections in a file named collections.csv in the current directory
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
@@ -12,7 +12,7 @@ organization_id="YOUR-ORGANIZATION-ID" # Set your Org ID
 
 # Perform CLI auth
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:replacewithyoursupersecretstring)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/exportOrgVaultCronjob.sh
+++ b/Bash Scripts/exportOrgVaultCronjob.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Depends on file "secureString.txt" and "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#99 > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#99 > secureString.txt
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_PERSONAL_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#99 > secureString_secret.txt
+# echo 'YOUR_PERSONAL_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#99 > secureString_secret.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
 # openssl is required in $PATH https://www.openssl.org/
@@ -43,10 +43,10 @@ fi
 
 
 
-personal_client_secret=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+personal_client_secret=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#99)
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#99)
  
 

--- a/Bash Scripts/inheritparentpermissions.sh
+++ b/Bash Scripts/inheritparentpermissions.sh
@@ -2,7 +2,7 @@
 # Depends on file "secureString.txt" which can be created as an encrypted file by replacing all references in this script to:
 # replacewithyoursupersecretstring
 # With your own encryption phrase, and then running:
-# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:replacewithyoursupersecretstring > secureString.txt
+# echo 'YOUR_MASTER_PASSWORD' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:replacewithyoursupersecretstring > secureString.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # bw is required in $PATH and logged in https://bitwarden.com/help/cli/
 # openssl is required in $PATH https://www.openssl.org/
@@ -11,7 +11,7 @@ organization_id="Change-With-Your-Org-ID" # Set your Org ID
 
 # Perform CLI auth
 
-password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+password=$(cat secureString.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:replacewithyoursupersecretstring)
 
 session_key="$(printf $password | bw unlock --raw)"

--- a/Bash Scripts/removeIndividualAccountPerms.sh
+++ b/Bash Scripts/removeIndividualAccountPerms.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Depends on file "secureString_secret.txt" which can be created by first running:
-# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 100000 -salt -pass pass:Secret@Bitwarden#69 > secureString_secret.txt
+# echo 'YOUR_ORG_SECRET_KEY' | openssl enc -aes-256-cbc -md sha512 -a -pbkdf2 -iter 600001 -salt -pass pass:Secret@Bitwarden#69 > secureString_secret.txt
 # jq is required in $PATH https://stedolan.github.io/jq/download/
 # openssl is required in $PATH https://www.openssl.org/
 
@@ -20,7 +20,7 @@ fi
 
 # Set up CLI and API auth
 
-org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 100000 \
+org_client_secret_key=$(cat secureString_secret.txt | openssl enc -aes-256-cbc -md sha512 -a -d -pbkdf2 -iter 600001 \
  -salt -pass pass:Secret@Bitwarden#69)
 org_client_id=("organization.$organization_id")
 


### PR DESCRIPTION
The original code called the API multiple times inside the loops with calls that were not dependent on the loop variables. Moved these outside the loops.

The original code assumed that admins/owners had access to all collections. When this is not the case, the collection is not created as there is no manager. Changed this by assigning the user in the create call.

Changed naming to Personal Collection/<email> as the Name is not always set, while the e-mail should always be set.